### PR TITLE
Add rule to enable removal in case of impasse

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ A move must only include filling in one number in one cell in the puzzle.
 * Moves are accepted in order of first submission.
 * Conflicting moves are skipped, they can be resubmitted ASAP once fixed.
 * Multiple players can submit a single joint pull requests consistent of many moves, one from each player.
+* If and only if no legal move may be played, a player may submit a PR to remove 1 number from the board. Removal of this number must enable additional moves to be played past the impasse it resolves. Removal of a number counts as a daily move.
 
 All other pull requests should improve the project in some way. Explained with what changes are made, and how it makes the project better.
 


### PR DESCRIPTION
If the board is played into an impassable state, there is currently no recourse to correct it. This adds a rule that lets a player use their one daily move to remove a played move if and only if:

* There are no legal moves available
* Removal of the number permits another to be played in its place that allows normal play to resume, or removal of the number enables more than one additional move to be played (moves which would have been blocked by its presence)